### PR TITLE
Add WP Cli to docker image and update composer file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,10 @@ RUN echo 'deb http://packages.dotdeb.org jessie all' >> /etc/apt/sources.list &&
       mysql-client \
       supervisor && \
     apt-get -q clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    echo "Install WP CLI globally" && \
+    curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
+    chmod +x /usr/local/bin/wp
 
 COPY config/docker/nginx.conf /etc/nginx/nginx.conf
 COPY config/docker/wordpress.conf.tpl /etc/nginx/wordpress.conf.tpl

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,11 @@
   ],
   "require": {
     "php": ">=5.6",
-    "composer/installers": "~1.0.12",
+    "composer/installers": "^1.4",
     "johnpbloch/wordpress": "4.9.4",
-    "phpunit/phpunit": "5.7.6",
     "vlucas/phpdotenv": "^2.0.1",
-    "wp-cli/wp-cli": "1.5.0",
-    "wpackagist-theme/twentyseventeen": "1.1"
+    "wpackagist-theme/twentyeighteen": "1.1",
+    "oscarotero/env": "^1.1.0"
   },
   "extra": {
     "installer-paths": {

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,1 @@
+path: web/wp


### PR DESCRIPTION
This commit adds the wp-cli to the docker image and updates the composer
file with latest versions of packages.